### PR TITLE
Migrated to Iroh 0.98

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "iroh-gossip-discovery"
-version = "0.6.0"
-edition = "2021"
+version = "0.6.1"
+edition = "2024"
 license = "MPL-2.0"
 description = "Discover iroh nodes via iroh-gossip"
 homepage = "https://github.com/therishidesai/iroh-gossip-discovery"
@@ -11,11 +11,19 @@ readme = "README.md"
 [dependencies]
 bytes = "1.10.1"
 dashmap = "6.1.0"
-ed25519-dalek = { version = "2.1", features = ["rand_core"] }
-rand = "0.8"
+
+ed25519-dalek = "3.0.0-pre.6"
+
+rand = "0.9.2"
 futures = "0.3"
-iroh = { version = "0.35.0", features = ["discovery-local-network"] }
-iroh-gossip = "0.35.0"
+
+iroh = { version = "0.98.1", features = ["address-lookup-mdns", "tls-ring"] }
+iroh-gossip = "0.98.0"
+iroh-base = "0.98.0"
+iroh-dns-server = "0.98.1"
+
+rustls = { version = "0.23.33", default-features = false }
+
 postcard = { version = "1.0", features = ["alloc"] }
 serde = { version = "1.0.219", features = ["derive"] }
 thiserror = "2.0.12"

--- a/examples/address_book_demo.rs
+++ b/examples/address_book_demo.rs
@@ -5,9 +5,10 @@ use iroh_gossip_discovery::{GossipDiscoveryBuilder, Node};
 use std::env;
 use std::str::FromStr;
 use std::sync::Arc;
-use tokio::time::{Duration, sleep};
+use tokio::{sync::Mutex, time::{Duration, sleep}};
 use tracing::{error, info, trace};
 use tracing_subscriber;
+
 #[derive(Debug, Copy, Clone, Default)]
 pub struct LocalDiscoveryPreset;
 
@@ -32,7 +33,7 @@ impl iroh::endpoint::presets::Preset for LocalDiscoveryPreset {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Initialize tracing with immediate output
+    // Initialize tracing
     tracing_subscriber::fmt()
         .with_target(false)
         .with_thread_ids(false)
@@ -45,6 +46,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         )
         .init();
 
+    // Parse args
     let args: Vec<String> = env::args().collect();
     if args.len() < 2 {
         eprintln!("Usage: {} <node_name> [seed_node_id]", args[0]);
@@ -60,122 +62,177 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         None
     };
 
+    // Endpoint
     let secret_key = SecretKey::generate();
-    let signing_key = ed25519_dalek::SigningKey::from_bytes(&secret_key.to_bytes());
-
-    let mut builder = Endpoint::builder(LocalDiscoveryPreset)
+    let endpoint = Endpoint::builder(LocalDiscoveryPreset)
         .secret_key(secret_key.clone())
-        .relay_mode(RelayMode::Disabled);
+        .relay_mode(RelayMode::Disabled)
+        .bind()
+        .await?;
 
-    let endpoint = builder.bind().await?;
+    // mDNS
+    let mdns = iroh::address_lookup::mdns::MdnsAddressLookup::builder()
+        .advertise(true)
+        .build(endpoint.id())
+        .unwrap();
 
-    let mdns = iroh::address_lookup::mdns::MdnsAddressLookup::builder().advertise(true).build(endpoint.id()).unwrap();
     endpoint.address_lookup()?.add(mdns.clone());
-    
-    
-    let _mdns_handle = tokio::spawn(async move {
-        let mut events = mdns.subscribe().await;
-        while let Some(event) = events.next().await {
-            trace!("[MDNS] {:?}", event);
-        }
-    });
-    
 
     info!(name = %node_name, node_id = %endpoint.id(), "Node started");
 
-    //let gossip = Gossip::builder().spawn(endpoint.clone()).await?;
-     let gossip = Gossip::builder().spawn(endpoint.clone());
-    
-    // Set up the router with gossip ALPN (required for gossip protocol)
+    // Gossip
+    let gossip = Gossip::builder().spawn(endpoint.clone());
+
+    // Router
     use iroh::protocol::Router;
     let _router = Router::builder(endpoint.clone())
         .accept(iroh_gossip::ALPN, gossip.clone())
         .spawn();
-    
-    let topic_id = TopicId::from([
-        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,
-        26, 27, 28, 29, 30, 31, 32,
-    ]);
 
-    // Initialize discovery with custom expiration timeout (60 seconds for demo)
-    let (mut sender, mut receiver) = if let Some(seed_id) = seed_node_id {
-        info!(%seed_id, "Connecting to seed node");
-        GossipDiscoveryBuilder::new()
-            .with_expiration_timeout(Duration::from_secs(60))
-            .build_with_peers(gossip, topic_id, vec![seed_id], &endpoint)
-            .await?
-    } else {
-        info!("Starting as first node - no existing peers to connect to");
-        // For the first node, start with empty peer list - this will create the initial gossip network
-        GossipDiscoveryBuilder::new()
-            .with_expiration_timeout(Duration::from_secs(60))
-            .build_with_peers(gossip, topic_id, vec![], &endpoint)
-            .await?
-    };
+    // Topic
+    let topic_id = TopicId::from([1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32]);
 
+    // -------------------------------
+    // DISCOVERY INITIALIZATION
+    // -------------------------------
+    let (mut sender, mut receiver) = GossipDiscoveryBuilder::new()
+        .with_expiration_timeout(Duration::from_secs(60))
+        .build_with_peers(
+            gossip.clone(),
+            topic_id,
+            seed_node_id.into_iter().collect(),
+            &endpoint,
+        )
+        .await?;
+
+    // -------------------------------
+    // CHANNEL for add_peer()
+    // -------------------------------
+    let (peer_tx, mut peer_rx) = tokio::sync::mpsc::unbounded_channel::<EndpointId>();
+
+    // -------------------------------
+    // mDNS → send peers in channel
+    // -------------------------------
+    let mdns_clone = mdns.clone();
+    let neighbor_map_for_mdns = receiver.neighbor_map.clone();
+    let peer_tx_mdns = peer_tx.clone();
+
+    tokio::spawn(async move {
+        let mut events = mdns_clone.subscribe().await;
+
+        while let Some(event) = events.next().await {
+            match event {
+                iroh::address_lookup::DiscoveryEvent::Discovered { endpoint_info, .. } => {
+                    trace!("[MDNS] discovered: {:?}", endpoint_info);
+
+                    // check if peer already known
+                    let already_known = neighbor_map_for_mdns
+                        .iter()
+                        .any(|entry| entry.value().node_id == endpoint_info.endpoint_id);
+
+                    if already_known {
+                        trace!("[MDNS] peer {} already known, skipping", endpoint_info.endpoint_id);
+                        continue;
+                    }
+
+                    // Peer in Channel senden
+                    let _ = peer_tx_mdns.send(endpoint_info.endpoint_id);
+                }
+                iroh::address_lookup::DiscoveryEvent::Expired { endpoint_id } => {
+                    trace!("[MDNS] expired: {endpoint_id}");
+                }
+                _ => {}
+            }
+        }
+    });
+
+    // -------------------------------
+    // DISCOVERY LOOP
+    // -------------------------------
     let node = Node {
         name: node_name.clone(),
         node_id: endpoint.id(),
         count: 0,
     };
 
-    // Get reference to neighbor map for periodic display
+    let sender_task = tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                Some(peer) = peer_rx.recv() => {
+                    if let Err(e) = sender.add_peer(peer).await {
+                        eprintln!("add_peer failed: {e}");
+                    }
+                }
+
+                result = sender.gossip(node.clone(), Duration::from_secs(3)) => {
+                    if let Err(e) = result {
+                        eprintln!("gossip error: {e}");
+                    }
+                    break;
+                }
+            }
+        }
+    });
+
+    // -------------------------------
+    // RECEIVER LOOP
+    // -------------------------------
     let neighbor_map = Arc::clone(&receiver.neighbor_map);
 
-    // Start receiver task
     let receiver_handle = tokio::spawn(async move {
         if let Err(e) = receiver.update_map().await {
             error!(%e, "Receiver error");
         }
     });
 
-    // Start sender task
-    let sender_node = node.clone();
-    let sender_handle = tokio::spawn(async move {
-        if let Err(e) = sender.gossip(sender_node, Duration::from_secs(3)).await {
-            error!(%e, "Sender error");
-        }
-    });
+    // -------------------------------
+    // DISPLAY LOOP
+    // -------------------------------
+    let display_handle = {
+        let node_name = node_name.clone();
+        let node_id = endpoint.id();
 
-    // Display address book periodically
-    let display_handle = tokio::spawn(async move {
-        let mut last_count = 0;
-        loop {
-            sleep(Duration::from_secs(5)).await;
+        tokio::spawn(async move {
+            let mut last_count = 0;
 
-            let neighbors: Vec<_> = neighbor_map
-                .iter()
-                .map(|entry| (entry.key().clone(), entry.value().node_id))
-                .collect();
+            loop {
+                sleep(Duration::from_secs(5)).await;
 
-            let current_count = neighbors.len();
-            if current_count != last_count || current_count == 0 {
-                info!("\n📚 Address Book Update:");
-                info!("   Self: {} ({})", &node_name, node.node_id);
+                let neighbors: Vec<_> = neighbor_map
+                    .iter()
+                    .map(|entry| (entry.key().clone(), entry.value().node_id))
+                    .collect();
 
-                if neighbors.is_empty() {
-                    info!("   👥 No peers discovered yet...");
-                } else {
-                    info!("   👥 Discovered peers ({}):", neighbors.len());
-                    for (name, id) in &neighbors {
-                        info!("      • {} ({})", name, id);
+                let current_count = neighbors.len();
+                if current_count != last_count || current_count == 0 {
+                    info!("\n📚 Address Book Update:");
+                    info!("   Self: {} ({})", &node_name, node_id);
+
+                    if neighbors.is_empty() {
+                        info!("   👥 No peers discovered yet...");
+                    } else {
+                        info!("   👥 Discovered peers ({}):", neighbors.len());
+                        for (name, id) in &neighbors {
+                            info!("      • {} ({})", name, id);
+                        }
                     }
+                    last_count = current_count;
                 }
-                last_count = current_count;
             }
-        }
-    });
+        })
+    };
 
-    // Keep running
+    // -------------------------------
+    // SHUTDOWN
+    // -------------------------------
     info!("\n🚀 Discovery system running... Press Ctrl+C to exit\n");
 
-    // Wait for Ctrl+C
     tokio::signal::ctrl_c().await?;
 
     info!("\n🛑 Shutting down...");
     receiver_handle.abort();
-    sender_handle.abort();
     display_handle.abort();
+    sender_task.abort();
 
     Ok(())
 }

--- a/examples/address_book_demo.rs
+++ b/examples/address_book_demo.rs
@@ -41,7 +41,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .compact()
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "iroh_gossip_discovery=info".into())
+                .unwrap_or_else(|_| "iroh_gossip_discovery=info,address_book_demo=info".into())
         )
         .init();
 

--- a/examples/address_book_demo.rs
+++ b/examples/address_book_demo.rs
@@ -1,12 +1,34 @@
-use iroh::NodeId;
+use futures::StreamExt;
+use iroh::{Endpoint, EndpointId, RelayMode, SecretKey, address_lookup::DnsAddressLookup, dns::DnsResolver};
 use iroh_gossip::{net::Gossip, proto::TopicId};
 use iroh_gossip_discovery::{GossipDiscoveryBuilder, Node};
 use std::env;
 use std::str::FromStr;
 use std::sync::Arc;
 use tokio::time::{Duration, sleep};
-use tracing::{info, error};
+use tracing::{error, info, trace};
 use tracing_subscriber;
+#[derive(Debug, Copy, Clone, Default)]
+pub struct LocalDiscoveryPreset;
+
+impl iroh::endpoint::presets::Preset for LocalDiscoveryPreset {
+    fn apply(
+        self,
+        mut builder: iroh::endpoint::Builder,
+    ) -> iroh::endpoint::Builder {
+
+        builder = builder.crypto_provider(Arc::new(rustls::crypto::ring::default_provider()));
+        
+        use iroh::RelayMode;
+        builder = builder.relay_mode(RelayMode::Disabled);
+
+        use iroh::address_lookup::MdnsAddressLookup;
+        builder = builder.address_lookup(MdnsAddressLookup::builder());
+
+
+        builder
+    }
+}
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -33,20 +55,36 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let node_name = args[1].clone();
     let seed_node_id = if args.len() > 2 {
-        Some(NodeId::from_str(&args[2])?)
+        Some(EndpointId::from_str(&args[2])?)
     } else {
         None
     };
 
-    // Create endpoint and gossip (with discovery enabled like the working example)
-    let endpoint = iroh::Endpoint::builder()
-        .discovery_n0()
-        .discovery_local_network()
-        .bind()
-        .await?;
-    info!(name = %node_name, node_id = %endpoint.node_id(), "Node started");
+    let secret_key = SecretKey::generate();
+    let signing_key = ed25519_dalek::SigningKey::from_bytes(&secret_key.to_bytes());
 
-    let gossip = Gossip::builder().spawn(endpoint.clone()).await?;
+    let mut builder = Endpoint::builder(LocalDiscoveryPreset)
+        .secret_key(secret_key.clone())
+        .relay_mode(RelayMode::Disabled);
+
+    let endpoint = builder.bind().await?;
+
+    let mdns = iroh::address_lookup::mdns::MdnsAddressLookup::builder().advertise(true).build(endpoint.id()).unwrap();
+    endpoint.address_lookup()?.add(mdns.clone());
+    
+    
+    let _mdns_handle = tokio::spawn(async move {
+        let mut events = mdns.subscribe().await;
+        while let Some(event) = events.next().await {
+            trace!("[MDNS] {:?}", event);
+        }
+    });
+    
+
+    info!(name = %node_name, node_id = %endpoint.id(), "Node started");
+
+    //let gossip = Gossip::builder().spawn(endpoint.clone()).await?;
+     let gossip = Gossip::builder().spawn(endpoint.clone());
     
     // Set up the router with gossip ALPN (required for gossip protocol)
     use iroh::protocol::Router;
@@ -77,7 +115,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let node = Node {
         name: node_name.clone(),
-        node_id: endpoint.node_id(),
+        node_id: endpoint.id(),
         count: 0,
     };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,11 +3,12 @@ use dashmap::DashMap;
 use ed25519_dalek::{Signature, Signer, SigningKey, Verifier, VerifyingKey};
 use futures::StreamExt;
 
-use iroh::NodeId;
+use iroh::{EndpointId, PublicKey};
 use iroh_gossip::{
-    net::{Event, Gossip, GossipEvent, GossipReceiver, GossipSender},
-    proto::TopicId,
+    api::GossipSender, net::Gossip, proto::TopicId
 };
+
+use iroh_gossip::api::{Event, GossipReceiver};
 
 use serde::{Deserialize, Serialize};
 
@@ -21,13 +22,13 @@ use tracing::{debug, error, info, warn};
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Node {
     pub name: String,
-    pub node_id: NodeId,
+    pub node_id: EndpointId,
     pub count: u32,
 }
 
 #[derive(Debug, Clone)]
 pub struct NodeInfo {
-    pub node_id: NodeId,
+    pub node_id: EndpointId,
     pub last_seen: Instant,
 }
 
@@ -75,6 +76,10 @@ impl SignedMessage {
 pub enum GossipDiscoveryError {
     #[error("Gossip error: {0}")]
     Gossip(#[from] iroh_gossip::net::Error),
+
+    #[error("API error: {0}")]
+    Api(#[from] iroh_gossip::api::ApiError),
+
     #[error("Channel send error")]
     ChannelSend,
     #[error("Serialization error: {0}")]
@@ -84,7 +89,7 @@ pub enum GossipDiscoveryError {
     #[error("Signature verification error: {0}")]
     SignatureVerification(String),
     #[error("NodeId mismatch: expected {expected}, got {actual}")]
-    NodeIdMismatch { expected: NodeId, actual: NodeId },
+    NodeIdMismatch { expected: EndpointId, actual: EndpointId },
 }
 
 pub type Result<T> = std::result::Result<T, GossipDiscoveryError>;
@@ -109,13 +114,15 @@ impl GossipDiscoveryBuilder {
         self,
         gossip: Gossip,
         topic_id: TopicId,
-        peers: Vec<NodeId>,
+        peers: Vec<EndpointId>,
         endpoint: &iroh::Endpoint,
     ) -> Result<(GossipDiscoverySender, GossipDiscoveryReceiver)> {
         // - First node (empty peers): use subscribe() only  
         // - Other nodes (with peers): use subscribe_and_join()
         info!("Attempting to subscribe to gossip topic");
-        let (sender, receiver) = gossip.subscribe(topic_id, peers)?.split();
+        //let (sender, receiver) = gossip.subscribe(topic_id, peers)?.split();
+        let topic = gossip.subscribe(topic_id, peers).await?;
+        let (sender, receiver) = topic.split();
         info!("Subscribed to gossip topic");
 
         let (peer_tx, peer_rx) = tokio::sync::mpsc::unbounded_channel();
@@ -145,14 +152,14 @@ impl GossipDiscoveryBuilder {
 }
 
 pub struct GossipDiscoverySender {
-    pub peer_rx: UnboundedReceiver<NodeId>,
+    pub peer_rx: UnboundedReceiver<EndpointId>,
     pub sender: GossipSender,
     pub secret_key: SigningKey,
 }
 
 impl GossipDiscoverySender {
     /// Add external peers to the gossip network
-    pub async fn add_peers(&mut self, peers: Vec<NodeId>) -> Result<()> {
+    pub async fn add_peers(&mut self, peers: Vec<EndpointId>) -> Result<()> {
         if !peers.is_empty() {
             info!(peer_count = peers.len(), "Adding external peers to gossip network");
             self.sender.join_peers(peers).await?;
@@ -161,7 +168,7 @@ impl GossipDiscoverySender {
     }
 
     /// Add a single external peer to the gossip network  
-    pub async fn add_peer(&mut self, peer: NodeId) -> Result<()> {
+    pub async fn add_peer(&mut self, peer: EndpointId) -> Result<()> {
         self.add_peers(vec![peer]).await
     }
 
@@ -201,7 +208,7 @@ impl GossipDiscoverySender {
 
 pub struct GossipDiscoveryReceiver {
     pub neighbor_map: Arc<DashMap<String, NodeInfo>>,
-    pub peer_tx: UnboundedSender<NodeId>,
+    pub peer_tx: UnboundedSender<EndpointId>,
     pub receiver: GossipReceiver,
     pub expiration_timeout: Duration,
 }
@@ -210,7 +217,7 @@ impl GossipDiscoveryReceiver {
     pub async fn update_map(&mut self) -> Result<()> {
         while let Some(res) = self.receiver.next().await {
             match res {
-                Ok(Event::Gossip(GossipEvent::Received(msg))) => {
+                Ok(Event::Received(msg)) => {
                     // Verify and decode the signed message
                     let (verifying_key, value) = match SignedMessage::verify_and_decode(&msg.content) {
                         Ok(result) => result,
@@ -221,7 +228,9 @@ impl GossipDiscoveryReceiver {
                     };
 
                     // Verify that the claimed node_id matches the public key
-                    let expected_node_id = NodeId::from(verifying_key);
+                    //let expected_node_id = EndpointId::from(verifying_key);
+                    let expected_node_id = PublicKey::from_bytes(&verifying_key.to_bytes()).unwrap();
+
                     if value.node_id != expected_node_id {
                         warn!(
                             claimed_node_id = %value.node_id,
@@ -259,7 +268,7 @@ impl GossipDiscoveryReceiver {
         Ok(())
     }
 
-    pub fn get_neighbors(&self) -> Vec<(String, NodeId)> {
+    pub fn get_neighbors(&self) -> Vec<(String, EndpointId)> {
         self.neighbor_map
             .iter()
             .map(|entry| (entry.key().clone(), entry.value().node_id))


### PR DESCRIPTION
Thanks for this example, I was searching for something like this using mDNS local only without external services!
Was hoping mDNS would work out of the box with gossip but ...

Don't know if there is any interest in updating it, but I got it running with this + iroh 0.98.
In addition I fixed that it prints the peer ID in the address-book example, as it was missing in the trace config.
For whatever reason it still tries to connect to an external IP 172.140.110.10 in my quick test but works without reaching it.